### PR TITLE
Add example configuration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@ Disable `pyright` and enable `basedpyright` in your settings.
   "languages": {
     "Python": {
       "language_servers": ["basedpyright", "!pyright"]
+  },
+}
+```
+
+## Configure
+
+Configure under `lsp.basedpyright.settings` as required.
+
+```jsonc
+{
+  "lsp": {
+    "basedpyright": {
+      "settings": {
+        "python": {
+          "pythonPath": ".venv/bin/python"
+        },
+        "basedpyright.analysis": {
+          "diagnosticMode": "workspace",
+          "inlayHints": {
+            "callArgumentNames": false
+          }
+        }
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
Configuration for the LSP is not entirely intuitive with the way Zed passes the settings onto the server, so a small example snippet in the README will be very useful for future reference.