### PR TITLE
Allow to configure path and arguments via LSP settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ Disable `pyright` and enable `basedpyright` in your settings.
 
 Configure under `lsp.basedpyright.settings` as required.
 
+The "binary" setting is optional, if not set, `basedpyright` will be searched for in your `PATH`.
+
 ```jsonc
 {
   "lsp": {
     "basedpyright": {
+      "binary": {
+        "path": ".venv/bin/basedpyright-langserver",
+        "arguments": ["--stdio"]
+      },
       "settings": {
         "python": {
           "pythonPath": ".venv/bin/python"

--- a/src/basedpyright.rs
+++ b/src/basedpyright.rs
@@ -12,6 +12,20 @@ impl zed::Extension for BasedPyright {
         worktree: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<zed_extension_api::Command> {
         let env = worktree.shell_env();
+
+        if let Ok(lsp_settings) = LspSettings::for_worktree("basedpyright", worktree) {
+            if let Some(binary) = lsp_settings.binary {
+                if let Some(path) = binary.path {
+                    let args = binary.arguments.unwrap_or(vec!["--stdio".to_string()]);
+                    return Ok(zed::Command {
+                        command: path,
+                        args,
+                        env,
+                    });
+                }
+            }
+        }
+
         let path = worktree
             .which("basedpyright-langserver")
             .ok_or_else(|| "basedpyright must be installed and available in $PATH.".to_string())?;


### PR DESCRIPTION
I have installed a specific version of `basedpyright` for my project and would like to set `basedpyright-langserver` in my zed project settings accordingly.

I therefore added the possibility to override the binary "path" and "arguments". I have copied this approach from https://github.com/zed-industries/zed/blob/main/extensions/zig/src/zig.rs and hope that it is OK here, too.